### PR TITLE
Write archive path of RECORD to RECORD instead of staging path

### DIFF
--- a/distlib/wheel.py
+++ b/distlib/wheel.py
@@ -301,10 +301,9 @@ class Wheel(object):
         result = base64.urlsafe_b64encode(result).rstrip(b'=').decode('ascii')
         return hash_kind, result
 
-    def write_record(self, records, record_path, base):
+    def write_record(self, records, record_path, archive_record_path):
         records = list(records) # make a copy, as mutated
-        p = to_posix(os.path.relpath(record_path, base))
-        records.append((p, '', ''))
+        records.append((archive_record_path, '', ''))
         with CSVWriter(record_path) as writer:
             for row in records:
                 writer.writerow(row)
@@ -321,8 +320,8 @@ class Wheel(object):
             records.append((ap, digest, size))
 
         p = os.path.join(distinfo, 'RECORD')
-        self.write_record(records, p, libdir)
         ap = to_posix(os.path.join(info_dir, 'RECORD'))
+        self.write_record(records, p, ap)
         archive_paths.append((ap, p))
 
     def build_zip(self, pathname, archive_paths):


### PR DESCRIPTION
This fix writes the _archive path_ of the dist-info RECORD file to itself, instead of the actual _filesystem path_, which might not match the path that is actually used in the final archive.

Simple script to reproduce the issue:

```py
import os
from distlib.wheel import Wheel
from pathlib import Path

whl = Wheel()
whl.name = 'test_package'
whl.version = '1.2.3b'
# Create staging folder with some dummy files to make into a wheel
stage_dir = Path('staging').resolve()
pkg_dir = stage_dir / whl.name
os.makedirs(pkg_dir, exist_ok=True)
(pkg_dir / '__init__.py').touch()
distinfo_dir = stage_dir / '.dist-info'
os.makedirs(distinfo_dir, exist_ok=True)
(distinfo_dir / 'METADATA').touch()
# Build wheel
paths = {'prefix': str(stage_dir), 'platlib': str(stage_dir)}
whl.dirname = os.getcwd()
wheel_path = whl.build(paths, wheel_version=(1, 0))
print(wheel_path)
```
Note that the metadata files in the staging folder are in the `.dist-info` subfolder. Its name doesn't matter, as long as it ends with `.dist-info`, `distlib.wheel` will automatically correct the name when creating a wheel: the directory of the metadata files in the wheel is changed to `test_package-1.2.3b.dist-info`, and records in the `RECORD` file also have the correct paths. However, the record of the `RECORD` file itself is incorrect, it refers to the `.dist-info` directory in the staging folder instead of the actual `test_package-1.2.3b.dist-info` directory where it lives in the package:

**`test_package-1.2.3b.dist-info/RECORD`** as generated by the above code
```text
test_package/__init__.py,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
test_package-1.2.3b.dist-info/METADATA,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
test_package-1.2.3b.dist-info/WHEEL,sha256=PtSGpc6OltwAryR9BT3i9ZPzXbacDpcSUEHpe9EuZIM,96
.dist-info/RECORD,,
```

The record of `RECORD` uses the filesystem path `p`:
https://github.com/pypa/distlib/blob/d0e3f49df5d1aeb9daeaaabf0391c9e13e4a6562/distlib/wheel.py#L304-L307
Whereas the records of all other files use the archive path `ap`:
https://github.com/pypa/distlib/blob/d0e3f49df5d1aeb9daeaaabf0391c9e13e4a6562/distlib/wheel.py#L316-L321

This patch fixes that, so the output becomes:
```text
test_package/__init__.py,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
test_package-1.2.3b.dist-info/METADATA,sha256=47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU,0
test_package-1.2.3b.dist-info/WHEEL,sha256=CfKgPt3S533HDV8egu6xXKrYHNG7AOT4NYdjL2Q0f6k,101
test_package-1.2.3b.dist-info/RECORD,,
```

(Granted, the problem doesn't occur if the user uses the _exact_ same name for the `dist-info` folder as `distlib` does, but there's no error message when this is not the case, and it's an easy fix, so I believe it's best to correct this.)