### PR TITLE
Source meta long description from the README file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = distlib
 version = attr: distlib.__version__
 description = Distribution utilities
-long_description = Low-level components of distutils2/packaging, augmented with higher-level APIs for making packaging easier.
+long_description = file: README.rst
 url = https://github.com/pypa/distlib
 author = Vinay Sajip
 author_email = vinay_sajip@red-dove.com


### PR DESCRIPTION
https://pypi.org/project/distlib/ looks empty with a one-liner. This should improve how it looks and make it a bit more informative.