### PR TITLE
Use version comparison logic for python_full_version.

### DIFF
--- a/distlib/markers.py
+++ b/distlib/markers.py
@@ -24,6 +24,10 @@ from .version import NormalizedVersion as NV
 __all__ = ['interpret']
 
 _VERSION_PATTERN = re.compile(r'((\d+(\.\d+)*\w*)|\'(\d+(\.\d+)*\w*)\'|\"(\d+(\.\d+)*\w*)\")')
+_VERSION_MARKERS = {'python_version', 'python_full_version'}
+
+def _is_version_marker(s):
+    return isinstance(s, string_types) and s in _VERSION_MARKERS
 
 def _is_literal(o):
     if not isinstance(o, string_types) or not o:
@@ -77,11 +81,11 @@ class Evaluator(object):
 
             lhs = self.evaluate(elhs, context)
             rhs = self.evaluate(erhs, context)
-            if ((elhs == 'python_version' or erhs == 'python_version') and
+            if ((_is_version_marker(elhs) or _is_version_marker(erhs)) and
                 op in ('<', '<=', '>', '>=', '===', '==', '!=', '~=')):
                 lhs = NV(lhs)
                 rhs = NV(rhs)
-            elif elhs == 'python_version' and op in ('in', 'not in'):
+            elif _is_version_marker(elhs) and op in ('in', 'not in'):
                 lhs = NV(lhs)
                 rhs = _get_versions(rhs)
             result = self.operations[op](lhs, rhs)

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -78,6 +78,12 @@ class MarkersTestCase(DistlibTestCase):
         self.assertTrue(interpret(
             "'buuuu' not in os_name and '%s' in os_name" % os_name))
 
+        # normalized version comparison correctness
+        self.assertTrue(interpret('python_version > "5.0"', {'python_version': '10.0'}))
+        self.assertTrue(interpret('python_version == "5.0"', {'python_version': '5.0'}))
+        self.assertTrue(interpret('python_version < "5.0"', {'python_version': '5.0b0'}))
+        self.assertTrue(interpret('python_full_version > "5.0"', {'python_full_version': '10.0'}))
+
         # execution context
         self.assertTrue(interpret('python_version == "0.1"',
                                   {'python_version': '0.1'}))


### PR DESCRIPTION
Currently, markers such as these don't yield the expected result: (Example from [black](https://github.com/psf/black/blob/main/pyproject.toml#L70).)

~~~
tomli>=1.1.0; python_full_version < '3.11.0a7'
~~~

This PR ensures that version comparison logic is used for `python_full_version`, as well as for `python_version`.