### PR TITLE
ci: Use 3.11 final and update actions versions.

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11-dev', 'pypy-2.7', 'pypy-3.9']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-2.7', 'pypy-3.9']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Test with unittest


### PR DESCRIPTION
v4 is needed to access 3.11 final, and it also is needed to stop the warning in CI about node 12 based actions being deprecated.