### PR TITLE
scriptmaker: fix regression that prevented proper shebang when building python

### DIFF
--- a/distlib/scripts.py
+++ b/distlib/scripts.py
@@ -168,15 +168,16 @@ class ScriptMaker(object):
             executable = os.path.join(sysconfig.get_path('scripts'),
                             'python%s' % sysconfig.get_config_var('EXE'))
         else:  # pragma: no cover
-            executable = os.path.join(
-                sysconfig.get_config_var('BINDIR'),
-               'python%s%s' % (sysconfig.get_config_var('VERSION'),
-                               sysconfig.get_config_var('EXE')))
-            if not os.path.isfile(executable):
+            if os.name == 'nt':
                 # for Python builds from source on Windows, no Python executables with
                 # a version suffix are created, so we use python.exe
                 executable = os.path.join(sysconfig.get_config_var('BINDIR'),
                                 'python%s' % (sysconfig.get_config_var('EXE')))
+            else:
+                executable = os.path.join(
+                    sysconfig.get_config_var('BINDIR'),
+                   'python%s%s' % (sysconfig.get_config_var('VERSION'),
+                                   sysconfig.get_config_var('EXE')))
         if options:
             executable = self._get_alternate_executable(executable, options)
 


### PR DESCRIPTION
In commit ad0ea221431689cb82c89b4942228fb07a87784d a special case was made to avoid the versioned python executable shebang in cases of sysconfig.is_python_build(), if and only if the resulting executable does not exist on disk. The stated rationale was for python builds from source on Windows, but the commit message claims it is ARM64-specific. The latter is untrue, and I cannot verify the former -- but it is certainly broken on platforms *other* than Windows, because when is_python_build() is true, BINDIR is where python would eventually install itself to, and the only thing guaranteed to exist is the in-progress build centered on sys.executable.

So the check always failed, and we never ended up using a versioned executable.

Assuming we need to handle Windows by not using a versioned executable, the appropriate way to handle this is to actually check for Windows, rather than to check for the executable and assume this tells us if we are on Windows.

Fixes https://github.com/python/cpython/issues/98183