### PR TITLE
Use SPDX license identifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description = file: README.rst
 url = https://github.com/pypa/distlib
 author = Vinay Sajip
 author_email = vinay_sajip@red-dove.com
-license = Python license
+license = PSF-2.0
 license_file = LICENSE.txt
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
Use SPDX license identifier: PSF-2.0
This will help tools to produce valid SPDX.