### PR TITLE
Check for cert_file attribute before accessing it

### DIFF
--- a/distlib/util.py
+++ b/distlib/util.py
@@ -1435,7 +1435,7 @@ if ssl:
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             if hasattr(ssl, 'OP_NO_SSLv2'):
                 context.options |= ssl.OP_NO_SSLv2
-            if self.cert_file:
+            if hasattr(self, "cert_file") and self.cert_file:
                 context.load_cert_chain(self.cert_file, self.key_file)
             kwargs = {}
             if self.ca_certs:

--- a/distlib/util.py
+++ b/distlib/util.py
@@ -1435,7 +1435,7 @@ if ssl:
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             if hasattr(ssl, 'OP_NO_SSLv2'):
                 context.options |= ssl.OP_NO_SSLv2
-            if hasattr(self, "cert_file") and self.cert_file:
+            if hasattr(self, 'cert_file') and self.cert_file:
                 context.load_cert_chain(self.cert_file, self.key_file)
             kwargs = {}
             if self.ca_certs:


### PR DESCRIPTION
In Python 3.12, HTTPSConnection no longer has cert_file attribute so unless something adds it to the subclass, the attribute doesn't exist by default.

CPython change: https://github.com/python/cpython/commit/ef0e72b31d22f780d3a165d7d0471806061fe380#diff-3cf29d90eb758d0fe5ec013bbfda9b0bb60be4f7d899583bd5f490a7a5a5dc5f

We are building distlib in Fedora Linux with Python 3.12 alpha 7 and it seems that with this change the tests are passing.