### PR TITLE
Preload script wrappers at import time

### DIFF
--- a/distlib/scripts.py
+++ b/distlib/scripts.py
@@ -56,15 +56,16 @@ if __name__ == '__main__':
 # location where it was imported from. So we load everything into memory in
 # advance.
 
-# Issue 31: don't hardcode an absolute package name, but
-# determine it relative to the current package
-distlib_package = __name__.rsplit('.', 1)[0]
+if os.name == 'nt' or (os.name == 'java' and os._name == 'nt'):
+    # Issue 31: don't hardcode an absolute package name, but
+    # determine it relative to the current package
+    DISTLIB_PACKAGE = __name__.rsplit('.', 1)[0]
 
-WRAPPERS = {
-    r.name: r.bytes
-    for r in finder(distlib_package).iterator("")
-    if r.name.endswith(".exe")
-}
+    WRAPPERS = {
+        r.name: r.bytes
+        for r in finder(DISTLIB_PACKAGE).iterator("")
+        if r.name.endswith(".exe")
+    }
 
 
 def enquote_executable(executable):
@@ -406,7 +407,7 @@ class ScriptMaker(object):
             name = '%s%s%s.exe' % (kind, bits, platform_suffix)
             if name not in WRAPPERS:
                 msg = ('Unable to find resource %s in package %s' %
-                       (name, distlib_package))
+                       (name, DISTLIB_PACKAGE))
                 raise ValueError(msg)
             return WRAPPERS[name]
 

--- a/distlib/scripts.py
+++ b/distlib/scripts.py
@@ -48,6 +48,24 @@ if __name__ == '__main__':
     sys.exit(%(func)s())
 '''
 
+# Pre-fetch the contents of all executable wrapper stubs.
+# This is to address https://github.com/pypa/pip/issues/12666.
+# When updating pip, we rename the old pip in place before installing the
+# new version. If we try to fetch a wrapper *after* that rename, the finder
+# machinery will be confused as the package is no longer available at the
+# location where it was imported from. So we load everything into memory in
+# advance.
+
+# Issue 31: don't hardcode an absolute package name, but
+# determine it relative to the current package
+distlib_package = __name__.rsplit('.', 1)[0]
+
+WRAPPERS = {
+    r.name: r.bytes
+    for r in finder(distlib_package).iterator("")
+    if r.name.endswith(".exe")
+}
+
 
 def enquote_executable(executable):
     if ' ' in executable:
@@ -386,14 +404,11 @@ class ScriptMaker(object):
                 bits = '32'
             platform_suffix = '-arm' if get_platform() == 'win-arm64' else ''
             name = '%s%s%s.exe' % (kind, bits, platform_suffix)
-            # Issue 31: don't hardcode an absolute package name, but
-            # determine it relative to the current package
-            distlib_package = __name__.rsplit('.', 1)[0]
-            resource = finder(distlib_package).find(name)
-            if not resource:
-                msg = ('Unable to find resource %s in package %s' % (name, distlib_package))
+            if name not in WRAPPERS:
+                msg = ('Unable to find resource %s in package %s' %
+                       (name, distlib_package))
                 raise ValueError(msg)
-            return resource.bytes
+            return WRAPPERS[name]
 
     # Public API follows
 


### PR DESCRIPTION
Pip encountered an issue (https://github.com/pypa/pip/issues/12666) where we can't find the script wrappers because we've uninstalled the running version of pip. Pre-loading the wrapper code into memory when importing `distlib.scripts` avoids this problem.

We can patch this locally, but would it be acceptable as a change here instead?