### PR TITLE
Add handling for cross-compilation environments.

### DIFF
--- a/distlib/scripts.py
+++ b/distlib/scripts.py
@@ -157,6 +157,12 @@ class ScriptMaker(object):
         """
         if os.name != 'posix':
             simple_shebang = True
+        elif getattr(sys, "cross_compiling", False):
+            # In a cross-compiling environment, the shebang will likely be a
+            # script; this *must* be invoked with the "safe" version of the
+            # shebang, or else using os.exec() to run the entry script will
+            # fail, raising "OSError 8 [Errno 8] Exec format error".
+            simple_shebang = False
         else:
             # Add 3 for '#!' prefix and newline suffix.
             shebang_length = len(executable) + len(post_interp) + 3


### PR DESCRIPTION
Adds handling to `_build_shebang()` that will unconditionally use the "non-simple" shebang if the current environment is marked as a cross-compilation environment.

In cross-compilation environments, the "python interpreter" can be a script that injects environmental modifications. However, these scripts then fail if they're used as a bare shebang, because they're not *strictly* an executable. The "non-simple" shebang is a workaround for this.

The marker for a cross-compilation environment is the one used by [crossenv](https://github.com/benfogle/crossenv/).

Fixes #230.