### PR TITLE
Upgrade codecov workflow to v4

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -53,7 +53,7 @@ jobs:
       env:
         PYTHONHASHSEED: 0
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         flags: unittests
         files: coverage.xml


### PR DESCRIPTION
v3 of https://github.com/codecov/codecov-action is failing on macOS, bumping to v4 appears to resolve the issue.