### PR TITLE
Guard script wrapper entrypoint import with `if __name__ == "__main__"`

### DIFF
--- a/distlib/scripts.py
+++ b/distlib/scripts.py
@@ -42,8 +42,8 @@ FIRST_LINE_RE = re.compile(b'^#!.*pythonw?[0-9.]*([ \t].*)?$')
 SCRIPT_TEMPLATE = r'''# -*- coding: utf-8 -*-
 import re
 import sys
-from %(module)s import %(import_name)s
 if __name__ == '__main__':
+    from %(module)s import %(import_name)s
     sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])
     sys.exit(%(func)s())
 '''


### PR DESCRIPTION
This way, the entrypoint will only be imported if the script wrapper is ran directly. This is beneficial for applications that use multiprocessing. multiprocessing imports the `__main__` module while initializing new workers to restore any global state the parallelized logic may rely on (e.g., a package-wide logger). Unfortunately, if the application is called using the console script wrapper (e.g., `pip install`), then the wrapper is the main module. For pip, this means every child process will import `venv/bin/pip` and consequently run `from pip._internal.cli.main import main` which is quite a heavy import.

(And yup, this means that multiprocessing is often slower when running `tool` compared to `python -m tool` if the application's `__main__.py` uses a `if __name__ == "__main__"` guard like pip.)

I hope this use-case is convincing enough. I do not wish to drag the discussion out like with what happened with #239. If you'd like a demo that shows the performance implications, I'm happy to write one. 

Concretely, this would let me remove [this awful hack from my PR parallelizing .pyc compilation](https://github.com/pypa/pip/pull/13247/commits/15ce2bff63348bff78808e3d01437aacfbd0d432#diff-4ca242d48938312113dfb08770c160ee01e84d73caae4e67bffa5bdb8bb4b605R27). 

Finally, I'll note that distlib's original script template had the entrypoint import under `if __name__ == "__main__"` before pip's template was synced over to distlib ~6 years ago: https://github.com/pypa/distlib/commit/ec0bceae9ecab8c98110fbd2d6d869a9deec82af. That seems to suggest that there shouldn't be any backwards compatibility concerns.