### PR TITLE
Update `test_wheel.WheelTestCase.test_abi` for freethreading

### DIFF
--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-2.7', 'pypy-3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', 'pypy-2.7', 'pypy-3.9']
         exclude:
           # macos-latest does not have Python 3.7
           - os: macos-latest

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', 'pypy-2.7', 'pypy-3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', 'pypy-2.7', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11']
         exclude:
           # macos-latest does not have Python 3.7
           - os: macos-latest

--- a/distlib/wheel.py
+++ b/distlib/wheel.py
@@ -71,6 +71,8 @@ else:
                     us = sysconfig.get_config_var('Py_UNICODE_SIZE')
                     if us == 4 or (us is None and sys.maxunicode == 0x10FFFF):
                         parts.append('u')
+            if bool(sysconfig.get_config_var("Py_GIL_DISABLED")):
+                parts.append('t')
         return ''.join(parts)
 
     ABI = _derive_abi()

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -719,6 +719,8 @@ class WheelTestCase(DistlibTestCase):
                 us = sysconfig.get_config_var('Py_UNICODE_SIZE')
                 if us == 4 or (us is None and sys.maxunicode == 0x10FFFF):
                     parts.append('u')
+            if bool(sysconfig.get_config_var("Py_GIL_DISABLED")):
+                parts.append('t')
         if vi < (3, 5):
             abi = ABI
         else:


### PR DESCRIPTION
Update `test_wheel.WheelTestCase.test_abi` to account for the `t` suffix added in freethreaded CPython builds.

Fixes #243