### PR TITLE
Normalize archive paths in dist-info

### DIFF
--- a/distlib/wheel.py
+++ b/distlib/wheel.py
@@ -448,7 +448,7 @@ class Wheel(object):
                 if fn not in ('RECORD', 'INSTALLER', 'SHARED', 'WHEEL'):
                     p = fsdecode(os.path.join(root, fn))
                     r = os.path.relpath(root, distinfo)
-                    ap = to_posix(os.path.join(info_dir, r, fn))
+                    ap = to_posix(os.path.normpath(os.path.join(info_dir, r, fn)))
                     archive_paths.append((ap, p))
 
         wheel_metadata = [


### PR DESCRIPTION
Normalize archive paths in dist-info. This resolves an issue introduced by #247, where paths in the RECORD file could contain things like `foo/./bar` (confusing tools such as cibuildwheel).