### PR TITLE
docs: update coverage results link

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -162,7 +162,7 @@ https://github.com/pypa/distlib/
 
 Coverage results are available at:
 
-https://coveralls.io/github/vsajip/distlib/
+https://app.codecov.io/gh/pypa/distlib/
 
 Continuous integration test results are available at:
 


### PR DESCRIPTION
The previous coverage report link (https://coveralls.io/github/vsajip/distlib/) has been replaced with the new Codecov link: https://app.codecov.io/gh/pypa/distlib.