### PR TITLE
Update cache_from_source() for Python 3.15

### DIFF
--- a/distlib/util.py
+++ b/distlib/util.py
@@ -589,7 +589,11 @@ class FileOperator(object):
                 self.dirs_created.add(path)
 
     def byte_compile(self, path, optimize=False, force=False, prefix=None, hashed_invalidation=False):
-        dpath = cache_from_source(path, not optimize)
+        if not optimize:
+            optimization = ''
+        else:
+            optimization = '1'
+        dpath = cache_from_source(path, optimization=optimization)
         logger.info('Byte-compiling %s to %s', path, dpath)
         if not self.dry_run:
             if force or self.newer(path, dpath):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -652,7 +652,7 @@ class FileOpsTestCase(DistlibTestCase):
 
     def test_byte_compile(self):
         path = os.path.join(self.workdir, 'hello.py')
-        dpath = cache_from_source(path, True)
+        dpath = cache_from_source(path, optimization='')
         self.fileop.write_text_file(path, 'print("Hello, world!")', 'utf-8')
         self.fileop.byte_compile(path, optimize=False)
         self.assertTrue(os.path.exists(dpath))


### PR DESCRIPTION
The debug_override parameter of cache_from_source() is deprecated in Python 3.14. The function docstring says:

    The debug_override parameter is deprecated. If debug_override
    is not None, a True value is the same as setting 'optimization'
    to the empty string while a False value is equivalent to setting
    'optimization' to '1'.

The parameter has been removed in Python 3.15.

Fixes #255