### PR TITLE
Fix URL percent-encoding using space-padding instead of zero-padding

### DIFF
--- a/distlib/locators.py
+++ b/distlib/locators.py
@@ -572,7 +572,7 @@ href\\s*=\\s*(?:"(?P<url1>[^"]*)"|'(?P<url2>[^']*)'|(?P<url3>[^>\\s\n]*))
             url = d['url1'] or d['url2'] or d['url3']
             url = urljoin(self.base_url, url)
             url = unescape(url)
-            url = self._clean_re.sub(lambda m: '%%%2x' % ord(m.group(0)), url)
+            url = self._clean_re.sub(lambda m: '%%%02x' % ord(m.group(0)), url)
             result.add((url, rel))
         # We sort the result, hoping to bring the most recent versions
         # to the front


### PR DESCRIPTION
## Summary

URL percent-encoding in `Page.links` uses `%2x` format which pads with a space instead of a zero for characters with ordinal values < 16.

## Problem

The format string `'%%%2x'` produces space-padded hex values:

```python
>>> '%%%2x' % 10
'% a'   # invalid URL encoding

>>> '%%%02x' % 10
'%0a'   # correct URL encoding
```

Characters like newline (0x0a), tab (0x09), etc. matched by `_clean_re` would be encoded as `% a`, `% 9`, etc. — these are not valid percent-encoded sequences per RFC 3986 and would break URL parsing.

## Fix

Change `%2x` to `%02x` to zero-pad the hex value.
