### PR TITLE
Use os.lstat in findall to correctly detect symlinked directories

### DIFF
--- a/distlib/manifest.py
+++ b/distlib/manifest.py
@@ -76,7 +76,7 @@ class Manifest(object):
                 fullname = os.path.join(root, name)
 
                 # Avoid excess stat calls -- just one will do, thank you!
-                stat = os.stat(fullname)
+                stat = os.lstat(fullname)
                 mode = stat.st_mode
                 if S_ISREG(mode):
                     allfiles.append(fsdecode(fullname))


### PR DESCRIPTION
## Summary

`Manifest.findall()` uses `os.stat()` which follows symlinks, making the `S_ISLNK(mode)` check dead code — symlinked directories are always traversed.

## Problem

```python
stat = os.stat(fullname)
mode = stat.st_mode
if S_ISREG(mode):
    allfiles.append(fsdecode(fullname))
elif S_ISDIR(mode) and not S_ISLNK(mode):
    push(fullname)
```

`os.stat()` follows symbolic links, so `stat.st_mode` always reflects the *target* of the symlink, never the symlink itself. `S_ISLNK(mode)` can only return `True` when the mode comes from `os.lstat()`, which returns info about the link itself.

As a result, symlinked directories are always added to the traversal stack. With circular symlinks (e.g. a directory that symlinks to a parent), this leads to infinite recursion.

## Fix

Use `os.lstat()` instead of `os.stat()` so that `S_ISLNK(mode)` works as intended.
